### PR TITLE
Fixes issue with servers ignoring JOIN cmds that are sent early

### DIFF
--- a/lib/irc_machine/core.rb
+++ b/lib/irc_machine/core.rb
@@ -5,7 +5,9 @@ module IrcMachine
       session.user options.user, options.realname
       session.nick options.nick
       session.state.nick = options.nick
-      options.channels.each { |c| session.join *c.split } if options.channels
+      EM::add_timer(5) do
+        options.channels.each { |c| session.join *c.split } if options.channels
+      end
     end
 
     def terminate


### PR DESCRIPTION
Simply puts a 5 second delay in. Ideally, we would wait until there is a
command from the server that signifies that its okay to keep sending,
but this works for now.
