### PR TITLE
Support password protected IRC servers

### DIFF
--- a/lib/irc_machine/commands.rb
+++ b/lib/irc_machine/commands.rb
@@ -10,6 +10,10 @@ module IrcMachine
       raw "USER #{user} 8 * :#{name}"
     end
 
+    def password(password)
+      raw "PASS #{password}"
+    end
+
     def nick(nick)
       raw "NICK #{nick}"
     end

--- a/lib/irc_machine/core.rb
+++ b/lib/irc_machine/core.rb
@@ -2,6 +2,7 @@ module IrcMachine
   class Core < Plugin::Base
 
     def connected
+      session.password options.password unless options.password.nil?
       session.user options.user, options.realname
       session.nick options.nick
       session.state.nick = options.nick


### PR DESCRIPTION
Just add `"password": "your_password",` to the irc_machine.json and it should connect to a password protected server.

Cheers!
