### PR TITLE
Remove FileUtils dependency. 

### DIFF
--- a/bin/irc_machined
+++ b/bin/irc_machined
@@ -21,6 +21,12 @@ IRC_MACHINE[:daemon] ||= {}
 
 daemon_params = daemon_defaults.merge(IRC_MACHINE[:daemon])
 
-FileUtils.mkdir_p(daemon_params[:log_dir])
+unless File.directory?(daemon_params[:log_dir])
+  begin
+    Dir::mkdir(daemon_params[:log_dir])
+  rescue
+    raise "Log directory #{daemon_params[:log_dir]} does not exist!"
+  end
+end
 
 Daemons.run(File.expand_path("../irc_machine", __FILE__), daemon_params)


### PR DESCRIPTION
I think it would be nice to keep dependencies to a minimum, this also makes it easier to install irc_machine in Debian.

Now it is creating log_dir directory if the directory over it exists. If it needs to create a directory recursive it will raise an error.

Cheers!
