### PR TITLE
Slashes in branchnames are totally legit

### DIFF
--- a/lib/irc_machine/plugin/github_notifier.rb
+++ b/lib/irc_machine/plugin/github_notifier.rb
@@ -26,7 +26,7 @@ module IrcMachine
       end
 
       def branch
-        data.ref.split("/").last
+        data.ref.gsub(%r{refs/heads/}, "")
       end
 
       def authors


### PR DESCRIPTION
Like in this branch ;)

Else the branch would come up as `slashes_in_branches` without the `bugs/`
