### PR TITLE
Pulls/jenkins github

### DIFF
--- a/lib/irc_machine.rb
+++ b/lib/irc_machine.rb
@@ -13,6 +13,7 @@ end
   irc_connection
   session
   state
+  routers
   plugin
   plugin/base
 
@@ -27,4 +28,5 @@ end
 end
 
 Dir[File.dirname(__FILE__) + '/irc_machine/models/*.rb'].each {|file| require file }
+Dir[File.dirname(__FILE__) + '/irc_machine/routers/*.rb'].each {|file| require file }
 Dir[File.dirname(__FILE__) + '/irc_machine/plugin/*.rb'].each {|file| require file }

--- a/lib/irc_machine/models/github_notification.rb
+++ b/lib/irc_machine/models/github_notification.rb
@@ -34,6 +34,10 @@ module IrcMachine
         data.before
       end
 
+      def commits
+        data.commits
+      end
+
       def owner
         OpenStruct.new(data.owner)
       end

--- a/lib/irc_machine/models/github_notification.rb
+++ b/lib/irc_machine/models/github_notification.rb
@@ -26,6 +26,22 @@ module IrcMachine
         data.ref.gsub(%r{refs/heads/}, "")
       end
 
+      def after
+        data.after
+      end
+
+      def before
+        data.before
+      end
+
+      def owner
+        OpenStruct.new(data.owner)
+      end
+
+      def repository
+        OpenStruct.new(data.repository)
+      end
+
       def authors
         data.commits.map{ |c| OpenStruct.new c["author"] }
       end

--- a/lib/irc_machine/models/jenkins_notification.rb
+++ b/lib/irc_machine/models/jenkins_notification.rb
@@ -1,0 +1,43 @@
+require "json"
+require "cgi"
+require "ostruct"
+
+module IrcMachine
+  module Models
+
+    class JenkinsNotification
+
+      attr_reader :data
+
+      def initialize(body)
+        @data = OpenStruct.new(JSON.parse(body))
+      end
+
+      def repo_name
+        data.name
+      end
+
+      def url
+        data.url
+      end
+
+      def full_url
+        data.build["full_url"]
+      end
+
+      def status
+        data.build["status"]
+      end
+
+      def phase
+        data.build["phase"]
+      end
+
+      def parameters
+        @parameters ||= OpenStruct.new(data.build["parameters"])
+      end
+
+    end
+
+  end
+end

--- a/lib/irc_machine/plugin/base.rb
+++ b/lib/irc_machine/plugin/base.rb
@@ -24,6 +24,7 @@ module IrcMachine
       def route(method, path, destination)
         # Close over the instance method and bind to a route.
         if destination.is_a? Symbol
+          sym = destination
           destination = lambda { |request, match| send(sym, request, match) }
         end
 

--- a/lib/irc_machine/plugin/github_jenkins.rb
+++ b/lib/irc_machine/plugin/github_jenkins.rb
@@ -58,7 +58,7 @@ class IrcMachine::Plugin::GithubJenkins < IrcMachine::Plugin::Base
 
       endpoint.on :completed, :failure do |commit, build| #{{{ Failure
         notify format_msg(commit, build)
-        notify "Jenkins output available at #{build.full_url}"
+        notify "Jenkins output available at #{build.full_url}console"
       end #}}}
 
       endpoint.on :completed, :aborted do |commit, build| #{{{ Aborted
@@ -67,7 +67,7 @@ class IrcMachine::Plugin::GithubJenkins < IrcMachine::Plugin::Base
 
       endpoint.on :unknown do |build| #{{{ Unknown
         notify "Unknown build of #{build.parameters.SHA1} completed with status #{build.status}"
-        notify "Jenkins output available at #{build.full_url}/console"
+        notify "Jenkins output available at #{build.full_url}console"
       end #}}}
     end
     route(:post, %r{^/github/jenkins_status$}, @notifier.endpoint)

--- a/lib/irc_machine/plugin/github_jenkins.rb
+++ b/lib/irc_machine/plugin/github_jenkins.rb
@@ -115,10 +115,15 @@ private
     { token: repo.token }
   end
 
+  def bold(txt)
+    "#{0x02.chr}#{txt}#{0x0F.chr}"
+  end
+
+
   def format_msg(commit, build)
      build_time = Time.now.to_i - commit.start_time
      commit = commit.commit
      authors = commit.author_usernames.map { |a| get_nick(a) }
-    "Build of #{commit.repo_name}/#{commit.branch} was a #{build.status} #{commit.repository.url}/compare/#{commit.before[0..6]}...#{commit.after[0..6]} in #{build_time}s PING #{authors.join(" ")}"
+    "Build of #{bold(commit.repo_name)}/#{bold(commit.branch)} was a #{bold(build.status)} #{commit.repository.url}/compare/#{commit.before[0..6]}...#{commit.after[0..6]} in #{bold(build_time)}s PING #{authors.join(" ")}"
   end
 end

--- a/lib/irc_machine/plugin/github_jenkins.rb
+++ b/lib/irc_machine/plugin/github_jenkins.rb
@@ -118,6 +118,7 @@ private
   def format_msg(commit, build)
      build_time = Time.now.to_i - commit.start_time
      commit = commit.commit
-    "Build of #{commit.repo_name}/#{commit.branch} was a #{build.status} #{commit.repository.url}/compare/#{commit.before[0..6]}...#{commit.after[0..6]} in #{build_time}s PING #{commit.author_usernames.join(" ")}"
+     authors = commit.author_usernames.map { |a| get_nick(a) }
+    "Build of #{commit.repo_name}/#{commit.branch} was a #{build.status} #{commit.repository.url}/compare/#{commit.before[0..6]}...#{commit.after[0..6]} in #{build_time}s PING #{authors.join(" ")}"
   end
 end

--- a/lib/irc_machine/plugin/github_jenkins.rb
+++ b/lib/irc_machine/plugin/github_jenkins.rb
@@ -119,11 +119,31 @@ private
     "#{0x02.chr}#{txt}#{0x0F.chr}"
   end
 
+  def color(txt, colorcode)
+    "#{0x03.chr}#{colorcode}#{txt}#{0x03.chr}"
+  end
+
+  def green(txt)
+    color(txt, 3)
+  end
+
+  def red(txt)
+    color(txt, 4)
+  end
 
   def format_msg(commit, build)
      build_time = Time.now.to_i - commit.start_time
      commit = commit.commit
      authors = commit.author_usernames.map { |a| get_nick(a) }
-    "Build of #{bold(commit.repo_name)}/#{bold(commit.branch)} was a #{bold(build.status)} #{commit.repository.url}/compare/#{commit.before[0..6]}...#{commit.after[0..6]} in #{bold(build_time)}s PING #{authors.join(" ")}"
+     status = case build.status
+              when "SUCCESS"
+                bold(green(build.status))
+              when "FAILURE"
+                bold(red(build.status))
+              else
+                build.status
+              end
+
+    "Build of #{bold(commit.repo_name)}/#{bold(commit.branch)} was a #{status} #{commit.repository.url}/compare/#{commit.before[0..6]}...#{commit.after[0..6]} in #{bold(build_time)}s PING #{authors.join(" ")}"
   end
 end

--- a/lib/irc_machine/plugin/github_jenkins.rb
+++ b/lib/irc_machine/plugin/github_jenkins.rb
@@ -1,0 +1,123 @@
+require 'net/http'
+# * Configuration
+# Project needs to be configured in jenkins with two parameters:
+# - SHA1 : Takes a sha hash to build
+# - ID   : Takes unique ID, purely for passing back to work out which build it
+#          was that we're looking at
+#
+# Then configuration in the .json file is
+# - {
+#     "settings": {
+#       "notify": "#builds"
+#     },
+#     "usernames": {
+#       "richoH": "richo"
+#     },
+#     "builds": {
+#       "reponame": {
+#         "builder_url": "URL GOES HERE",
+#         "token"      : "JENKINS_TOKEN",
+#       }
+#     }
+#   }
+#
+# usernames is an optional hash of github -> irc nickname mappings so that users can be usefully notified
+#
+class IrcMachine::Plugin::GithubJenkins < IrcMachine::Plugin::Base
+
+  CONFIG_FILE = "github_jenkins.json"
+
+  attr_reader :settings
+  def initialize(*args)
+    @repos = Hash.new
+    @builds = Hash.new
+    conf = load_config
+
+    conf["builds"].each do |k, v|
+      @repos[k] = OpenStruct.new(v)
+    end
+
+    @settings = OpenStruct.new(conf["settings"])
+    @usernames = conf["usernames"] || {}
+
+    route(:post, %r{^/github/jenkins$}, :build_branch)
+
+    initialize_jenkins_notifier
+    super(*args)
+  end
+
+  def initialize_jenkins_notifier
+    @notifier = ::IrcMachine::Routers::JenkinsRouter.new(@builds) do |endpoint|
+      endpoint.on :started do |commit, build|#{{{ Started
+        commit.start_time = Time.now.to_i
+      end #}}}
+
+      endpoint.on :completed, :success do |commit, build|#{{{ Success
+        notify format_msg(commit, build)
+      end #}}}
+
+      endpoint.on :completed, :failure do |commit, build| #{{{ Failure
+        notify format_msg(commit, build)
+        notify "Jenkins output available at #{build.full_url}"
+      end #}}}
+
+      endpoint.on :completed, :aborted do |commit, build| #{{{ Aborted
+        notify "Build of #{commit.repo_name}/#{commit.branch} ABORTED"
+      end #}}}
+
+      endpoint.on :unknown do |build| #{{{ Unknown
+        notify "Unknown build of #{build.parameters.SHA1} completed with status #{build.status}"
+        notify "Jenkins output available at #{build.full_url}/console"
+      end #}}}
+    end
+    route(:post, %r{^/github/jenkins_status$}, @notifier.endpoint)
+  end
+
+  def build_branch(request, match)
+    commit = ::IrcMachine::Models::GithubNotification.new(request.body.read)
+
+    if repo = @repos[commit.repo_name]
+      trigger_build(repo, commit)
+    else
+      not_found
+    end
+  end
+
+  def notify(msg)
+    session.msg settings.notify, msg
+  end
+
+private
+
+  def get_nick(author)
+    @usernames[author] || author
+  end
+
+  def trigger_build(repo, commit)
+    uri = URI(repo.builder_url)
+    id = next_id
+    @builds[id.to_s] = OpenStruct.new({ repo: repo, commit: commit, start_time: 0})
+    params = defaultParams(repo).merge ({SHA1: commit.after, ID: id})
+
+    uri.query = URI.encode_www_form(params)
+    return Net::HTTP.get(uri).is_a? Net::HTTPSuccess
+  end
+
+  def load_config
+    JSON.load(open(File.expand_path(CONFIG_FILE)))
+  end
+
+  def next_id
+    Time.now.to_i
+  end
+
+  def defaultParams(repo)
+    { token: repo.token }
+  end
+
+  def format_msg(commit, build)
+     build_time = Time.now.to_i - commit.start_time
+     commit = commit.commit
+    "Build of #{commit.repo_name}/#{commit.branch} was a #{build.status} #{commit.repository.url}/compare/#{commit.before[0..6]}...#{commit.after[0..6]} in #{build_time}s PING #{commit.author_usernames.join(" ")}"
+  end
+end

--- a/lib/irc_machine/routers.rb
+++ b/lib/irc_machine/routers.rb
@@ -1,0 +1,4 @@
+module IrcMachine
+  module Routers
+  end
+end

--- a/lib/irc_machine/routers/jenkins_router.rb
+++ b/lib/irc_machine/routers/jenkins_router.rb
@@ -1,0 +1,58 @@
+# This is not a valid plugin, it can't be directly attached to an endpoint.
+#
+# I just couldn't work out where else this code belonged.
+#
+# Usage:
+#  def initialize_jenkins_notifier
+#    @notifier = JenkinsNotifier.new(@builds) do |endpoint|
+#      endpoint.on :success do |commit, build|#{{{ Success
+#        notify format_msg(commit, build)
+#      end #}}}
+#
+#      endpoint.on :failure do |commit, build| #{{{ Failure
+#        notify format_msg(commit, build)
+#        notify "Jenkins output available at #{build.full_url}"
+#      end #}}}
+#    end
+#  end
+#
+#  With subsequent calls to
+#  @notifier.process([body of jenkins notification])
+class IrcMachine::Routers::JenkinsRouter
+  attr_reader :builds, :triggers
+  def initialize(builds)
+    @builds = builds
+    @triggers = {}
+    if block_given?
+      yield self
+    end
+  end
+
+  def on(phase, status=:any, &block)
+    triggers[phase] ||= {}
+    triggers[phase][status] = block
+  end
+
+  def process(message)
+    build = ::IrcMachine::Models::JenkinsNotification.new(message)
+
+    if match = triggers[build.phase.downcase.to_sym]
+      if commit = @builds[build.parameters.ID.to_s]
+        if block = match[build.status.downcase.to_sym] rescue nil
+          block.call(commit, build)
+        elsif block = match[:any]
+          block.call(commit, build)
+        end
+      else
+        if block = triggers[:unknown][:any]
+          block.call(build)
+        end
+      end
+    end
+  end
+
+  def endpoint
+    lambda { |request, match| process(request.body.read) }
+  end
+end
+


### PR DESCRIPTION
This PR gives irc_machine a few new features:
- A router class that you can leverage to have upstream deal with jenkins CI notification plugin messages and create a few routes internally
- A fix to my previous PR for routable procs that makes them actually work...
- The vast majority of the functionality of github's janky
