### PR TITLE
Let the route accept a block directly

### DIFF
--- a/lib/irc_machine/plugin/base.rb
+++ b/lib/irc_machine/plugin/base.rb
@@ -21,10 +21,15 @@ module IrcMachine
         end
       end
 
-      def route(method, path, destination)
+      def route(method, path, destination=nil, &block)
         # Close over the instance method and bind to a route.
         if destination.is_a? Symbol
+          sym = destination
           destination = lambda { |request, match| send(sym, request, match) }
+        elsif block_given?
+          destination = block
+        elsif destination.nil?
+          raise "Can't route without a destination or a block"
         end
 
         IrcMachine::HttpRouter.send(:connect, method, path, destination)


### PR DESCRIPTION
This includes the fix for the `Proc` syntax, as well as the fairly logical option to just pass in a block.
